### PR TITLE
refactor(core): rename Attribute.Wight to Attribute.Weight

### DIFF
--- a/packages/core/src/attribute.ts
+++ b/packages/core/src/attribute.ts
@@ -8,7 +8,7 @@ export const enum Attribute {
    * - S：采样值
    * - N：0表示不稳定，1表示稳定，2表示超重
    */
-  Wight = 'WGT',
+  Weight = 'WGT',
   /**
    * 设置归零的采样值
    *

--- a/packages/core/src/opper.ts
+++ b/packages/core/src/opper.ts
@@ -50,7 +50,7 @@ export class Opper {
   );
 
   private readonly rawWeightChange = this.attributeCommandChange.pipe(
-    filter(o => o.attribute === Attribute.Wight),
+    filter(o => o.attribute === Attribute.Weight),
     share()
   );
 
@@ -84,7 +84,7 @@ export class Opper {
   }
 
   readonly sampleChange = this.attributeCommandChange.pipe(
-    filter(cmd => cmd.attribute === Attribute.Wight),
+    filter(cmd => cmd.attribute === Attribute.Weight),
     map(cmd => +cmd.value[1]),
     shareReplay(1)
   );

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -23,7 +23,7 @@ export function createAttributeCommand(att: Attribute, value?: string | number |
 }
 
 export function verifyAttributeCommand(cmd: string) {
-  if (cmd.startsWith(createAttributeToken(Attribute.Wight))) {
+  if (cmd.startsWith(createAttributeToken(Attribute.Weight))) {
     return ATT_WGT_PATTERN.test(cmd);
   }
 


### PR DESCRIPTION
Fixes #37

Rename `Attribute.Wight` enum to `Attribute.Weight` in the core package.

* **packages/core/src/attribute.ts**
  - Rename the `Attribute.Wight` enum to `Attribute.Weight`.

* **packages/core/src/opper.ts**
  - Update the references to `Attribute.Wight` to `Attribute.Weight`.

* **packages/core/src/utils.ts**
  - Update the references to `Attribute.Wight` to `Attribute.Weight`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/opper-devkit/opper-js-sdk/issues/37?shareId=6de6868a-777f-4602-a8ed-a932cd52d025).